### PR TITLE
Remove pmc dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(BUILD_MATLAB_BINDINGS "Build MATLAB bindings" OFF)
 option(USE_ASAN "Enable address sanitizer" OFF)
 option(USE_SYSTEM_EIGEN3 "Use system pre-installed Eigen" ON)
 option(ENABLE_DIAGNOSTIC_PRINT "Enable printing of diagnostic messages" OFF)
+option(WITH_PMC "Enable usage of pmc (GPL License - see notice)" OFF)
 
 if (ENABLE_DIAGNOSTIC_PRINT)
     message(STATUS "Enable printing of diagnostic messages.")
@@ -46,11 +47,34 @@ endif ()
 # Dependencies
 #
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-find_external_dependency("Eigen3" "Eigen3::Eigen" "${CMAKE_CURRENT_LIST_DIR}/cmake/DownloadEigen.cmake")
-find_package(OpenMP QUIET REQUIRED)
-robin_download_pmc()
-robin_download_xenium()
-add_subdirectory(${pmc_SOURCE_DIR} ${pmc_BINARY_DIR})
+find_package(Eigen3)
+if(NOT Eigen3_FOUND)
+    message(STATUS "Eigen3 not found. Downloading Eigen3.")
+    find_external_dependency("Eigen3" "Eigen3::Eigen" "${CMAKE_CURRENT_LIST_DIR}/cmake/DownloadEigen.cmake")
+endif()
+
+find_package(OpenMP REQUIRED)
+
+# pmc
+if(WITH_PMC)
+    message(WARNING "PMC is licensed under the GPL.  Enabling WITH_PMC will cause the resulting 'robin' library to be licensed under the GPL.")
+    find_package(pmc QUIET)
+    if(NOT pmc_FOUND)
+        robin_download_pmc()
+        add_subdirectory(${pmc_SOURCE_DIR} ${pmc_BINARY_DIR})
+    endif()
+    
+endif()
+
+find_package(xenium QUIET)
+if(NOT xenium_FOUND)
+    message(STATUS "Xenium not found. Downloading Xenium.")
+    robin_download_xenium()
+    #  Set the flag after downloading
+    set(XENIUM_DOWNLOADED TRUE)
+else()
+    set(XENIUM_DOWNLOADED FALSE)
+endif()
 
 #
 # Add robin target
@@ -63,18 +87,33 @@ file(GLOB
 
 add_library(robin STATIC ${SOURCE_FILES})
 add_library(robin::robin ALIAS robin)
+
+if(WITH_PMC)
 target_link_libraries(robin
         PUBLIC Eigen3::Eigen
-               xenium
+        xenium
         PRIVATE OpenMP::OpenMP_CXX
         PRIVATE pmc)
+        target_compile_definitions(robin PRIVATE USE_PMC) # CHANGED THIS LINE
+else()
+target_link_libraries(robin
+        PUBLIC Eigen3::Eigen
+        xenium
+        PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
 target_include_directories(
         robin
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        ${Eigen3_INCLUDE_DIRS}
+        ${xenium_INCLUDE_DIRS}
 )
+
+
+
 
 if (USE_ASAN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fPIC")
@@ -111,13 +150,23 @@ export(
         NAMESPACE robin::
 )
 
-install(
-    TARGETS xenium pmc
-    EXPORT robinTargets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
+if(xenium_FOUND AND XENIUM_DOWNLOADED)
+    install(
+        TARGETS xenium
+        EXPORT robinTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+endif()
 
+if(WITH_PMC AND pmc_FOUND)
+    install(
+        TARGETS pmc
+        EXPORT robinTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+endif()
 
 install(
         EXPORT robinTargets
@@ -135,10 +184,12 @@ install(
 
 install(DIRECTORY include/robin DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-# To set forcibly xeniumConfig.cmake
-install(FILES cmake/xeniumConfig.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/xenium
-        )
+if(xenium_FOUND)
+    # To set forcibly xeniumConfig.cmake
+    install(FILES cmake/xeniumConfig.cmake
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/xenium
+            )
+endif()
 
 export(PACKAGE robin)
 

--- a/include/robin/core.hpp
+++ b/include/robin/core.hpp
@@ -221,7 +221,7 @@ public:
       std::queue<EdgeType> edge_buffer;
 
 #pragma omp for
-      for (size_t k = 0; k < N * (N - 1) / 2; ++k) {
+      for (long k = 0; k < N * (N - 1) / 2; ++k) {
         size_t i = k / N;
         size_t j = k % N;
         if (j <= i) {
@@ -293,7 +293,7 @@ public:
 
 #pragma omp for
       // visit each edge twice
-      for (size_t i = 0; i < N; ++i) {
+      for (long i = 0; i < N; ++i) {
         for (size_t j = 0; j < N; ++j) {
           subset_indices[0] = i;
           subset_indices[1] = j;
@@ -332,7 +332,7 @@ public:
 
 #pragma omp for
       // for loop that goes through each (i,j) edge twice
-      for (size_t i = 0; i < N; ++i) {
+      for (long i = 0; i < N; ++i) {
         for (size_t j = 0; j < N; ++j) {
           subset_indices[0] = i;
           subset_indices[1] = j;
@@ -366,7 +366,7 @@ public:
 
 #pragma omp for
       // for loop that goes through each (i,j) edge twice
-      for (size_t i = 0; i < N; ++i) {
+      for (long i = 0; i < N; ++i) {
         for (size_t j = 0; j < N; ++j) {
           subset_indices[0] = i;
           subset_indices[1] = j;
@@ -411,7 +411,7 @@ public:
       auto* subset_indices = new size_t[2];
 
 #pragma omp for
-      for (size_t k = 0; k < N * (N - 1) / 2; ++k) {
+      for (long k = 0; k < N * (N - 1) / 2; ++k) {
         size_t i = k / N;
         size_t j = k % N;
         if (j <= i) {
@@ -451,7 +451,7 @@ public:
       auto* subset_indices = new size_t[2];
 
 #pragma omp for
-      for (size_t k = 0; k < N * (N - 1) / 2; ++k) {
+      for (long k = 0; k < N * (N - 1) / 2; ++k) {
         size_t i = k / N;
         size_t j = k % N;
         if (j <= i) {

--- a/include/robin/graph_solvers.hpp
+++ b/include/robin/graph_solvers.hpp
@@ -68,6 +68,7 @@ private:
   size_t max_k_core_number_ = 0;
 };
 
+#ifdef USE_PMC
 /**
  * A facade to the Parallel Maximum Clique (PMC) library.
  *
@@ -119,5 +120,5 @@ public:
 private:
   Params params_;
 };
-
+#endif
 }

--- a/include/robin/pkc.hpp
+++ b/include/robin/pkc.hpp
@@ -61,24 +61,6 @@ struct graph_t {
 void BZ_kCores(const IGraph& g, std::vector<size_t>* deg);
 
 /**
- * @brief K-core decomposition with parallel PKC. This is the non-optimized version.
- * Each thread has its own queue -- parallel PKC_org for k-core decomposition
- *
- * @param g
- * @param deg
- */
-void PKC_original(const IGraph& g, size_t* deg);
-
-/**
- * @brief K-core decomposition with parallel PKC. This particular function is suitable for large
- * graph, with optimization detailed in the original paper.
- *
- * @param g
- * @param deg
- */
-void PKC_optimized(const IGraph& g, size_t* deg);
-
-/**
  * @brief Interface with robin::Graph for K-core decomposition with parallel PKC.
  * @param g
  * @param core

--- a/include/robin/problems.hpp
+++ b/include/robin/problems.hpp
@@ -5,7 +5,7 @@
 // See LICENSE for the license information
 
 #pragma once
-
+#define M_PI       3.14159265358979323846   // pi
 #define _USE_MATH_DEFINES
 
 #include <cmath>

--- a/include/robin/robin.hpp
+++ b/include/robin/robin.hpp
@@ -25,7 +25,9 @@ namespace robin {
 //
 enum class InlierGraphStructure {
   MAX_CORE = 0,
+#ifdef USE_PMC  
   MAX_CLIQUE = 1,
+#endif
 };
 
 std::vector<size_t> FindInlierStructure(const IGraph* g, InlierGraphStructure graph_structure);

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -9,7 +9,9 @@
 #include <omp.h>
 #include <random>
 
+#ifdef USE_PMC
 #include <pmc/pmc.h>
+#endif
 #include <robin/graph.hpp>
 #include <robin/pkc.hpp>
 

--- a/src/graph_solvers.cpp
+++ b/src/graph_solvers.cpp
@@ -4,7 +4,9 @@
 // Authors: Jingnan Shi, et al. (see THANKS for the full author list)
 // See LICENSE for the license information
 
+#ifdef USE_PMC
 #include <pmc/pmc.h>
+#endif
 #include <robin/pkc.hpp>
 #include <robin/graph_core.hpp>
 #include <robin/graph_solvers.hpp>
@@ -56,6 +58,7 @@ std::vector<size_t> KCoreDecompositionSolver::GetKCore(const size_t& k) {
   return k_core;
 }
 
+#ifdef USE_PMC
 //
 // Definitions for the MaxCliqueSolver class
 //
@@ -154,5 +157,5 @@ std::vector<size_t> MaxCliqueSolver::FindMaxClique(const IGraph& graph) const {
   vector<size_t> C_result(C.begin(), C.end());
   return C_result;
 }
-
+#endif
 }

--- a/src/robin.cpp
+++ b/src/robin.cpp
@@ -16,12 +16,16 @@ std::vector<size_t> robin::FindInlierStructure(const IGraph* g,
     k_core_decomposition_solver.Solve(*g);
     return k_core_decomposition_solver.GetMaxKCore();
   }
+#ifdef USE_PMC
   case InlierGraphStructure::MAX_CLIQUE: {
     robin::MaxCliqueSolver::Params clique_params;
     clique_params.solver_mode = robin::MaxCliqueSolver::CLIQUE_SOLVER_MODE::PMC_EXACT;
     robin::MaxCliqueSolver clique_solver(clique_params);
     return clique_solver.FindMaxClique(*g);
   }
+#endif
+  default:
+    throw std::invalid_argument("Invalid graph structure type.");
   }
 }
 

--- a/tests/core_test.cpp
+++ b/tests/core_test.cpp
@@ -103,10 +103,12 @@ TEST_CASE("large compatibility graph csr") {
   for (size_t i = 0; i < trials; ++i) {
     auto start = std::chrono::high_resolution_clock::now();
     auto* g = graph_constructor.BuildCompGraph(robin::GraphsStorageType::CSR);
+    
     auto t1 = std::chrono::high_resolution_clock::now();
-
+#ifdef USE_PMC
     auto actual_max_clique_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
+#endif        
     auto t2 = std::chrono::high_resolution_clock::now();
 
     auto actual_max_core_indices =
@@ -115,13 +117,17 @@ TEST_CASE("large compatibility graph csr") {
 
     graph_construction_time +=
         std::chrono::duration_cast<std::chrono::milliseconds>(t1 - start).count();
+#ifdef USE_PMC        
     clique_finding_time += std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+#endif    
     core_finding_time += std::chrono::duration_cast<std::chrono::milliseconds>(t3 - t2).count();
 
     delete g;
   }
   std::cout << "Graph time  (ms): " << graph_construction_time / trials << std::endl;
+#ifdef USE_PMC  
   std::cout << "Clique time (ms): " << clique_finding_time / trials << std::endl;
+#endif  
   std::cout << "Core time   (ms): " << core_finding_time / trials << std::endl;
 }
 
@@ -183,9 +189,10 @@ TEST_CASE("large compatibility graph atomic csr") {
     auto start = std::chrono::high_resolution_clock::now();
     auto* g = graph_constructor.BuildCompGraph(robin::GraphsStorageType::ATOMIC_CSR);
     auto t1 = std::chrono::high_resolution_clock::now();
-
+#ifdef USE_PMC
     auto actual_max_clique_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
+#endif        
     auto t2 = std::chrono::high_resolution_clock::now();
 
     auto actual_max_core_indices =
@@ -194,13 +201,17 @@ TEST_CASE("large compatibility graph atomic csr") {
 
     graph_construction_time +=
         std::chrono::duration_cast<std::chrono::milliseconds>(t1 - start).count();
+#ifdef USE_PMC        
     clique_finding_time += std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+#endif    
     core_finding_time += std::chrono::duration_cast<std::chrono::milliseconds>(t3 - t2).count();
 
     delete g;
   }
   std::cout << "Graph time  (ms): " << graph_construction_time / trials << std::endl;
+#ifdef USE_PMC  
   std::cout << "Clique time (ms): " << clique_finding_time / trials << std::endl;
+#endif  
   std::cout << "Core time   (ms): " << core_finding_time / trials << std::endl;
 }
 
@@ -262,9 +273,10 @@ TEST_CASE("large compatibility graph adj list") {
     auto start = std::chrono::high_resolution_clock::now();
     auto* g = graph_constructor.BuildCompGraph(robin::GraphsStorageType::ADJ_LIST);
     auto t1 = std::chrono::high_resolution_clock::now();
-
+#ifdef USE_PMC  
     auto actual_max_clique_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
+#endif        
     auto t2 = std::chrono::high_resolution_clock::now();
 
     auto actual_max_core_indices =
@@ -273,13 +285,17 @@ TEST_CASE("large compatibility graph adj list") {
 
     graph_construction_time +=
         std::chrono::duration_cast<std::chrono::milliseconds>(t1 - start).count();
+#ifdef USE_PMC        
     clique_finding_time += std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+#endif    
     core_finding_time += std::chrono::duration_cast<std::chrono::milliseconds>(t3 - t2).count();
 
     delete g;
   }
   std::cout << "Graph time  (ms): " << graph_construction_time / trials << std::endl;
+#ifdef USE_PMC
   std::cout << "Clique time (ms): " << clique_finding_time / trials << std::endl;
+#endif
   std::cout << "Core time   (ms): " << core_finding_time / trials << std::endl;
 }
 
@@ -343,6 +359,7 @@ TEST_CASE("sample comp graph construction") {
     std::sort(max_core.begin(), max_core.end());
     REQUIRE_THAT(max_core, Catch::Equals(expected_inliers_sizet));
 
+#ifdef USE_PMC
     // find clique
     robin::MaxCliqueSolver::Params clique_params;
     clique_params.solver_mode = robin::MaxCliqueSolver::CLIQUE_SOLVER_MODE::PMC_EXACT;
@@ -350,6 +367,7 @@ TEST_CASE("sample comp graph construction") {
     auto clique = clique_solver.FindMaxClique(*g);
     std::sort(clique.begin(), clique.end());
     REQUIRE_THAT(clique, Catch::Equals(expected_inliers_sizet));
+#endif
 
     delete g;
   }

--- a/tests/graph_solvers_test.cpp
+++ b/tests/graph_solvers_test.cpp
@@ -208,6 +208,7 @@ TEST_CASE("k-core solver large graphs") {
   }
 }
 
+#ifdef USE_PMC
 TEST_CASE("max clique small graphs") {
   SECTION("complete graph") {
     // A complete graph with max clique # = 5
@@ -296,3 +297,4 @@ TEST_CASE("max clique multiple threads") {
     runner(g, 126);
   }
 }
+#endif

--- a/tests/robin_test.cpp
+++ b/tests/robin_test.cpp
@@ -48,11 +48,13 @@ TEST_CASE("vector averaging") {
   auto actual_max_core_indices =
       robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
   std::sort(actual_max_core_indices.begin(), actual_max_core_indices.end());
+#ifdef USE_PMC
   auto actual_max_clique_indices =
       robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
   std::sort(actual_max_clique_indices.begin(), actual_max_clique_indices.end());
 
   REQUIRE_THAT(actual_max_clique_indices, Catch::Equals(expected_inliers));
+#endif  
   REQUIRE_THAT(actual_max_core_indices, Catch::Equals(expected_inliers));
 
   delete g;
@@ -89,11 +91,13 @@ TEST_CASE("vector averaging csr") {
   auto actual_max_core_indices =
       robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
   std::sort(actual_max_core_indices.begin(), actual_max_core_indices.end());
+#ifdef USE_PMC
   auto actual_max_clique_indices =
       robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
   std::sort(actual_max_clique_indices.begin(), actual_max_clique_indices.end());
 
   REQUIRE_THAT(actual_max_clique_indices, Catch::Equals(expected_inliers));
+#endif  
   REQUIRE_THAT(actual_max_core_indices, Catch::Equals(expected_inliers));
 
   delete g;
@@ -131,11 +135,13 @@ TEST_CASE("vector averaging atomic csr") {
   auto actual_max_core_indices =
       robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
   std::sort(actual_max_core_indices.begin(), actual_max_core_indices.end());
+#ifdef USE_PMC  
   auto actual_max_clique_indices =
       robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
   std::sort(actual_max_clique_indices.begin(), actual_max_clique_indices.end());
 
   REQUIRE_THAT(actual_max_clique_indices, Catch::Equals(expected_inliers));
+#endif  
   REQUIRE_THAT(actual_max_core_indices, Catch::Equals(expected_inliers));
 
   delete g;
@@ -173,11 +179,13 @@ TEST_CASE("vector averaging adj list") {
   auto actual_max_core_indices =
       robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
   std::sort(actual_max_core_indices.begin(), actual_max_core_indices.end());
+#ifdef USE_PMC  
   auto actual_max_clique_indices =
       robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
   std::sort(actual_max_clique_indices.begin(), actual_max_clique_indices.end());
 
   REQUIRE_THAT(actual_max_clique_indices, Catch::Equals(expected_inliers));
+#endif  
   REQUIRE_THAT(actual_max_core_indices, Catch::Equals(expected_inliers));
 
   delete g;
@@ -211,14 +219,17 @@ TEST_CASE("single rotation averaging") {
     auto actual_max_core_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
     std::sort(actual_max_core_indices.begin(), actual_max_core_indices.end());
+#ifdef USE_PMC    
     auto actual_max_clique_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
     std::sort(actual_max_clique_indices.begin(), actual_max_clique_indices.end());
-
+#endif
     // check results
     std::vector<size_t> expected_inliers = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+#ifdef USE_PMC        
     REQUIRE_THAT(actual_max_clique_indices, Catch::Equals(expected_inliers));
-
+#endif
+    REQUIRE_THAT(actual_max_core_indices, Catch::Equals(expected_inliers));
     delete g;
   }
 
@@ -239,13 +250,15 @@ TEST_CASE("single rotation averaging") {
     auto actual_max_core_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
     std::sort(actual_max_core_indices.begin(), actual_max_core_indices.end());
+#ifdef USE_PMC
     auto actual_max_clique_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
     std::sort(actual_max_clique_indices.begin(), actual_max_clique_indices.end());
 
     // check results
     REQUIRE_THAT(actual_max_clique_indices, Catch::Equals(expected_inliers));
-
+#endif
+    REQUIRE_THAT(actual_max_core_indices, Catch::Equals(expected_inliers));
     delete g;
   }
 }
@@ -293,14 +306,17 @@ TEST_CASE("3d reg") {
     auto actual_max_core_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
     std::sort(actual_max_core_indices.begin(), actual_max_core_indices.end());
+#ifdef USE_PMC    
     auto actual_max_clique_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
     std::sort(actual_max_clique_indices.begin(), actual_max_clique_indices.end());
-
+#endif
     // no outliers
     std::vector<size_t> expected_inliers = {0, 1, 2, 3, 4};
+#ifdef USE_PMC     
     REQUIRE_THAT(actual_max_clique_indices, Catch::Equals(expected_inliers));
-
+#endif    
+    REQUIRE_THAT(actual_max_core_indices, Catch::Equals(expected_inliers));
     delete g;
   }
 
@@ -339,14 +355,17 @@ TEST_CASE("3d reg") {
     auto actual_max_core_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
     std::sort(actual_max_core_indices.begin(), actual_max_core_indices.end());
+#ifdef USE_PMC    
     auto actual_max_clique_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
     std::sort(actual_max_clique_indices.begin(), actual_max_clique_indices.end());
-
+#endif
     // outlier at index 2
     std::vector<size_t> expected_inliers = {0, 1, 3, 4};
+#ifdef USE_PMC        
     REQUIRE_THAT(actual_max_clique_indices, Catch::Equals(expected_inliers));
-
+#endif
+    REQUIRE_THAT(actual_max_core_indices, Catch::Equals(expected_inliers));
     delete g;
   }
 }
@@ -391,9 +410,11 @@ TEST_CASE("3d reg large instance") {
   auto actual_max_core_indices =
       robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
   std::sort(actual_max_core_indices.begin(), actual_max_core_indices.end());
+#ifdef USE_PMC  
   auto actual_max_clique_indices =
       robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
   std::sort(actual_max_clique_indices.begin(), actual_max_clique_indices.end());
+#endif  
 
   delete g;
 }
@@ -449,12 +470,13 @@ TEST_CASE("3d reg with normals") {
     auto actual_max_core_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
     std::sort(actual_max_core_indices.begin(), actual_max_core_indices.end());
+#ifdef USE_PMC
     auto actual_max_clique_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
     std::sort(actual_max_clique_indices.begin(), actual_max_clique_indices.end());
 
     REQUIRE_THAT(actual_max_clique_indices, Catch::Equals(expected_inliers));
-
+#endif
     delete g;
   }
 
@@ -515,12 +537,13 @@ TEST_CASE("3d reg with normals") {
     auto actual_max_core_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
     std::sort(actual_max_core_indices.begin(), actual_max_core_indices.end());
+#ifdef USE_PMC    
     auto actual_max_clique_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
     std::sort(actual_max_clique_indices.begin(), actual_max_clique_indices.end());
-
-    REQUIRE_THAT(actual_max_core_indices, Catch::Equals(expected_inliers));
     REQUIRE_THAT(actual_max_clique_indices, Catch::Equals(expected_inliers));
+#endif
+    REQUIRE_THAT(actual_max_core_indices, Catch::Equals(expected_inliers));
 
     // new (larger) noise bound
     // with this noise bound, the outlier should not be identified
@@ -533,13 +556,16 @@ TEST_CASE("3d reg with normals") {
     auto actual_max_core_indices_2 =
         robin::FindInlierStructure(g2, robin::InlierGraphStructure::MAX_CORE);
     std::sort(actual_max_core_indices_2.begin(), actual_max_core_indices_2.end());
+#ifdef USE_PMC    
     auto actual_max_clique_indices_2 =
         robin::FindInlierStructure(g2, robin::InlierGraphStructure::MAX_CLIQUE);
     std::sort(actual_max_clique_indices_2.begin(), actual_max_clique_indices_2.end());
-
+#endif
     std::vector<size_t> expected_inliers_2 = {0, 1, 2, 4};
     REQUIRE_THAT(actual_max_core_indices, Catch::Equals(expected_inliers_2));
+#ifdef USE_PMC    
     REQUIRE_THAT(actual_max_clique_indices, Catch::Equals(expected_inliers_2));
+#endif
 
     delete g;
     delete g2;
@@ -603,7 +629,7 @@ TEST_CASE("3d reg with normals") {
 
     // call robin API
     auto* g = robin::Make3dNormalRegInvGraph(src, tgt, noise_bound);
-
+#ifdef USE_PMC
     // find the clique
     auto actual_max_clique_indices =
         robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
@@ -616,8 +642,9 @@ TEST_CASE("3d reg with normals") {
         robin::FindInlierStructure(g_points, robin::InlierGraphStructure::MAX_CLIQUE);
     std::sort(actual_points_max_clique_indices.begin(), actual_points_max_clique_indices.end());
     REQUIRE_THAT(actual_points_max_clique_indices, Catch::Equals(actual_max_clique_indices));
-
-    delete g;
     delete g_points;
+#endif
+    delete g;
+    
   }
 }


### PR DESCRIPTION
Introduce WITH_PMC CMake option to conditionally disable the PMC dependency, aligning with the MIT license. This change also resolves compilation issues on Windows with the MSVC compiler.