### PR TITLE
bump cmake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.5)
 project(robin
         VERSION 1.2.3
         DESCRIPTION "Robust outlier rejection based on measurement compatibility graphs"


### PR DESCRIPTION
Bump cmake minimum version to 3.5 from 3.18 since support for versions <3.5 is deprecated and removed.
This causes build issues in other projects, such as KISS-Matcher, which include ROBIN as a third party library.

This PR would also require a subsequent release to solve the [issue](https://github.com/MIT-SPARK/KISS-Matcher/issues/64) raised in KISS-Matcher.

See https://discourse.cmake.org/t/cmake-4-0-0-rc1-is-ready-for-testing/13606
