### PR TITLE
Adds missing assert header

### DIFF
--- a/include/robin/graph_core.hpp
+++ b/include/robin/graph_core.hpp
@@ -24,6 +24,8 @@
 #include <robin/utils.hpp>
 #include <robin/views.hpp>
 
+#include <cassert>
+
 namespace robin {
 
 //

--- a/matlab/mex_utils.hpp
+++ b/matlab/mex_utils.hpp
@@ -12,6 +12,8 @@
 
 #include <Eigen/Core>
 
+#include <cassert>
+
 // Credit to Effective Modern C++ Item 10
 template <typename E> constexpr typename std::underlying_type<E>::type toUType(E e) noexcept {
   return static_cast<typename std::underlying_type<E>::type>(e);


### PR DESCRIPTION
The cassert header was missing from some files,
leading to potential compilation issues. This change adds
the missing header to ensure proper assert functionality.
