### PR TITLE
Bump cmake minumum required

### DIFF
--- a/cmake/DownloadProject.CMakeLists.cmake.in
+++ b/cmake/DownloadProject.CMakeLists.cmake.in
@@ -1,7 +1,7 @@
 # Distributed under the OSI-approved MIT License.  See accompanying
 # file LICENSE or https://github.com/Crascit/DownloadProject for details.
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(${DL_ARGS_PROJ}-download NONE)
 


### PR DESCRIPTION
Small fix to make ROBIN work with newer CMake versions.