### PR TITLE
ci: give sdist/wheel artifacts unique names (fix 409 Conflict)

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -23,6 +23,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: dist-sdist
           path: dist/*.tar.gz
 
   cibuildwheel:
@@ -70,6 +71,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: dist-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   pypi:
@@ -79,7 +81,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: dist-*
+          merge-multiple: true
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Both `build_sdist` and `cibuildwheel` jobs in `pypi.yml` were uploading via `actions/upload-artifact@v4` without specifying `name:`, so both defaulted to `artifact` — `upload-artifact@v4` rejects duplicate names within a run (v3 used to merge), causing intermittent **409 Conflict** failures depending on which job uploaded second.
- Observed on PR #12's CI run [25769512563](https://github.com/MIT-SPARK/ROBIN/actions/runs/25769512563) — sdist uploaded fine, wheel upload then failed with `Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict`. The build itself was clean.
- This is a latent flake on master that affects every PR/release run; the previous `fix/msvc-pmc-werror` run only succeeded because the wheel job happened to upload first.

## Fix
- `build_sdist` uploads as `dist-sdist`
- `cibuildwheel` uploads as `dist-wheels-${{ matrix.os }}` (matrix-friendly for future OS additions)
- The release-only `pypi` job downloads with `pattern: dist-*` + `merge-multiple: true` to reconstruct the single `dist/` directory `pypa/gh-action-pypi-publish` expects

## Test plan
- [ ] Verify this PR's own CI run completes without 409 Conflict
- [ ] Verify both `dist-sdist` and `dist-wheels-ubuntu-22.04` artifacts appear on the run page
- [ ] After merge, re-check #12 (rebased) to confirm CI passes end-to-end
- [ ] Next release tag: `pypi` job should still collect both sdist and wheel into `dist/` for publishing